### PR TITLE
LPS-19845 - Update chat portlet w/ server time offset

### DIFF
--- a/portlets/chat-portlet/docroot/js/main.js
+++ b/portlets/chat-portlet/docroot/js/main.js
@@ -40,7 +40,11 @@ AUI().use(
 			getCurrentTimestamp: function() {
 				var instance = this;
 
-				return (new Date()).getTime();
+				var currentChatServerTime = A.one('#currentChatServerTime').val() || 0;
+
+				var offset = A.Lang.now() - currentChatServerTime;
+
+				return A.Lang.now() - offset;
 			},
 
 			getUserImagePath: function(userId) {

--- a/portlets/chat-portlet/docroot/view.jsp
+++ b/portlets/chat-portlet/docroot/view.jsp
@@ -164,4 +164,6 @@
 
 		</div>
 	</div>
+
+	<aui:input name="currentChatServerTime" type="hidden" useNamespace="false" value="<%= System.currentTimeMillis() %>" />
 </c:if>


### PR DESCRIPTION
Hey Nate,

Attached is the fix for the Chat Portlet issue where if the server time is behind the user time, the user will never receive new messages. The issue is in reference to:

http://issues.liferay.com/browse/LPS-19845

Please let me know if you have any questions. Thanks!
- Jon Mak
