### PR TITLE
LPS-21219 - Remove use of substitute module

### DIFF
--- a/portlets/opensocial-portlet/docroot/gadget/js/main.js
+++ b/portlets/opensocial-portlet/docroot/gadget/js/main.js
@@ -177,7 +177,7 @@ AUI().add(
 							instance._iframe = container.getIframe();
 						}
 						else {
-							var iframe = A.substitute(
+							var iframe = Lang.sub(
 								TPL_IFRAME,
 								{
 									height: (height ? 'height="' + height + '"' : STR_EMPTY),


### PR DESCRIPTION
Hey Nate,

I thought I sent this to you, but it looks like I havent.  Attached is the update for the opensocial-gadget plugin to remove the substitue module with the AUI().Lang.sub() method. The ticket can be found at:

http://issues.liferay.com/browse/LPS-21219

Please let me know if you have any questions. Thanks!
- Jon Mak
