### PR TITLE
LPS-26115 Fix possible infinite chat-portlet panel width

### DIFF
--- a/portlets/chat-portlet/docroot/css/main.css
+++ b/portlets/chat-portlet/docroot/css/main.css
@@ -261,6 +261,7 @@ html body {
 	border: 1px solid #262626;
 	font: 12px Tahoma, Geneva, sans-serif;
 	min-width: 226px;
+	max-width: 452px;
 	position: relative;
 }
 
@@ -336,6 +337,8 @@ html body {
 	height: 192px;
 	overflow-y: scroll;
 	padding: 2px;
+	overflow-x: auto;
+	word-wrap: break-word;
 
 	.blurb {
 		margin: 0;


### PR DESCRIPTION
This fixes the possible infinite witdth for chat-portlet conversation panels. Browsers not supporting `word-wrap: break-word` will ignore it and fall back to a reasonable maximum width with an added horizontal scrollbar if the content still doesn't fit. An horizontal scrollbar is never nice, but it's better than hiding important content.
