### PR TITLE
LPS-42944

### DIFF
--- a/portlets/chat-portlet/docroot/js/main.js
+++ b/portlets/chat-portlet/docroot/js/main.js
@@ -1220,12 +1220,8 @@ AUI().use(
 				if (instance._initialRequest) {
 					instance._loadCache(entries);
 
-					if (instance._openPanelId.length) {
-						var openPanelId = parseInt(instance._openPanelId, 10);
-
-						if (!isNaN(openPanelId)) {
-							instance._createChatFromUser(instance._openPanelId);
-						}
+					if (instance._openPanelId && !isNaN(instance._openPanelId)) {
+						instance._createChatFromUser(instance._openPanelId);
 					}
 
 					instance._restoreMinimizedPanels();

--- a/portlets/chat-portlet/docroot/js/main.js
+++ b/portlets/chat-portlet/docroot/js/main.js
@@ -1220,8 +1220,12 @@ AUI().use(
 				if (instance._initialRequest) {
 					instance._loadCache(entries);
 
-					if (instance._openPanelId && !isNaN(instance._openPanelId)) {
-						instance._createChatFromUser(instance._openPanelId);
+					if (instance._openPanelId) {
+						openPanelId = parseInt(instance._openPanelId, 10);
+
+						if (Lang.isNumber(openPanelId)) {
+							instance._createChatFromUser(instance._openPanelId);
+						}
 					}
 
 					instance._restoreMinimizedPanels();


### PR DESCRIPTION
Hey @natecavanaugh,

Attached is an update for http://issues.liferay.com/browse/LPS-42944.  I checked the logic and ```buddylist``` and ```settings``` are being sent as a string, so when we pass them to ```parseInt()```, it will not be returned as a numerical value.  A chat window will not be created then.

Please let me know if you have any questions.

Thanks!